### PR TITLE
fix(cosmoz-dropdown-menu): limit list height to 96vh-64px

### DIFF
--- a/src/cosmoz-dropdown.js
+++ b/src/cosmoz-dropdown.js
@@ -72,7 +72,11 @@ const preventDefault = e => e.preventDefault(),
 	},
 	List = () => html`
 		<style>
-			:host { display: contents; }
+			:host {
+				display: contents;
+				max-height: var(--cosmoz-dropdown-menu-max-height, calc(96vh - 64px));
+				overflow-y: auto;
+			}
 			::slotted(:not(slot)) {
 				display: block;
 				--paper-button_-_display: block;


### PR DESCRIPTION
Limit the height of the list to 96vh - 64px.
Allow changing the max height per in instace with css vars.
