### PR TITLE
feat: remove the popover padding

### DIFF
--- a/src/cosmoz-dropdown.ts
+++ b/src/cosmoz-dropdown.ts
@@ -44,8 +44,8 @@ const Content = (host: HTMLElement & ContentProps) => {
 			:host(:popover-open) {
 				margin: 0;
 				border: 0;
-				/* The padding is needed to show the box shadow in Chrome */
-				padding: 4px;
+				padding: 0;
+				overflow: visible;
 			}
 			.wrap {
 				background: var(--cosmoz-dropdown-bg-color, #fff);


### PR DESCRIPTION
Remove the `popover` padding while retaining the box shadow