### PR TITLE
feat: set `background-color` on popover element

### DIFF
--- a/src/cosmoz-dropdown.ts
+++ b/src/cosmoz-dropdown.ts
@@ -46,6 +46,7 @@ const Content = (host: HTMLElement & ContentProps) => {
 				border: 0;
 				padding: 0;
 				overflow: visible;
+				background: var(--cosmoz-dropdown-bg-color, #fff);
 			}
 			.wrap {
 				background: var(--cosmoz-dropdown-bg-color, #fff);


### PR DESCRIPTION
Make sure the `background-color` for the dropdown menu is being set by `--cosmoz-dropdown-bg-color` variable.