### PR TITLE
fix: preserve dropdown content and dialog escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
 			"@semantic-release/npm",
 			"@semantic-release/git"
 		],
-		"branch": "master",
+		"branches": [
+			"master",
+			{
+				"name": "beta",
+				"prerelease": true
+			}
+		],
 		"preset": "conventionalcommits"
 	},
 	"publishConfig": {

--- a/src/cosmoz-dropdown.ts
+++ b/src/cosmoz-dropdown.ts
@@ -1,9 +1,8 @@
-import { component, css } from '@pionjs/pion';
+import { component, css, useCallback, useEffect, useRef } from '@pionjs/pion';
 import { html, nothing } from 'lit-html';
 import { guard } from 'lit-html/directives/guard.js';
 import { ref } from 'lit-html/directives/ref.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
-import { when } from 'lit-html/directives/when.js';
 import { Content } from './cosmoz-dropdown-content';
 import { useFloating, UseFloating } from './use-floating';
 import { UseFocusOpts, useHostFocus } from './use-focus';
@@ -39,12 +38,35 @@ const style = css`
 const Dropdown = (host: HTMLElement & Props) => {
 	const { placement, strategy, middleware, render } = host;
 	const { active, onToggle } = useHostFocus(host);
+	const contentRef = useRef<HTMLElement>();
 	const { styles, setReference, setFloating } = useFloating({
 		placement,
 		strategy,
 		middleware,
 	});
-	return html` <div class="anchor" part="anchor" ${ref(setReference)}>
+	const setContent = useCallback(
+		(el?: Element) => {
+			contentRef.current = el as HTMLElement | undefined;
+			setFloating(el as HTMLElement | undefined);
+		},
+		[setFloating],
+	);
+
+	useEffect(() => {
+		const content = contentRef.current;
+		if (!content) {
+			return;
+		}
+		if (active && !content.matches(':popover-open')) {
+			content.showPopover?.();
+		}
+		if (!active && content.matches(':popover-open')) {
+			content.hidePopover?.();
+		}
+	}, [active]);
+
+	return html`
+		<div class="anchor" part="anchor" ${ref(setReference)}>
 			<button
 				@mousedown=${preventDefault}
 				@click=${onToggle}
@@ -54,23 +76,19 @@ const Dropdown = (host: HTMLElement & Props) => {
 				<slot name="button">...</slot>
 			</button>
 		</div>
-		${when(
-			active,
-			() =>
-				html`<cosmoz-dropdown-content
-					popover
-					id="content"
-					part="content"
-					exportparts="wrap, content"
-					style="${styleMap(styles)}"
-					@connected=${(e: Event) => (e.target as HTMLElement).showPopover?.()}
-					${ref(setFloating)}
-					><slot></slot>${guard(
-						[render],
-						() => render?.() || nothing,
-					)}</cosmoz-dropdown-content
-				> `,
-		)}`;
+		<cosmoz-dropdown-content
+			popover
+			id="content"
+			part="content"
+			exportparts="wrap, content"
+			style="${styleMap(styles)}"
+			${ref(setContent)}
+			><slot></slot>${guard(
+				[render],
+				() => render?.() || nothing,
+			)}</cosmoz-dropdown-content
+		>
+	`;
 };
 customElements.define(
 	'cosmoz-dropdown',

--- a/src/use-focus.ts
+++ b/src/use-focus.ts
@@ -1,7 +1,9 @@
-import { useEffect, useState, useCallback } from '@pionjs/pion';
 import { useMeta } from '@neovici/cosmoz-utils/hooks/use-meta';
+import { useCallback, useEffect, useState } from '@pionjs/pion';
 
 const isFocused = (t: Element) => t.matches(':focus-within');
+const hasOpenDialogInPath = (e: Event) =>
+	e.composedPath().some((el) => el instanceof HTMLDialogElement && el.open);
 
 interface FocusState {
 	focused?: boolean;
@@ -33,6 +35,9 @@ export const useFocus = ({ disabled, onFocus }: UseFocusOpts) => {
 		}
 		const handler = (e: KeyboardEvent) => {
 			if (e.defaultPrevented) {
+				return;
+			}
+			if (e.key === 'Escape' && hasOpenDialogInPath(e)) {
 				return;
 			}
 			const { closed } = meta;

--- a/test/cosmoz-dropdown.test.ts
+++ b/test/cosmoz-dropdown.test.ts
@@ -1,5 +1,5 @@
+import { expect, fixture, html, nextFrame } from '@open-wc/testing';
 import '../src/cosmoz-dropdown';
-import { expect, html, fixture, nextFrame } from '@open-wc/testing';
 
 describe('cosmoz-dropdown', () => {
 	it('render', async () => {
@@ -9,5 +9,87 @@ describe('cosmoz-dropdown', () => {
 		el.shadowRoot!.querySelector<HTMLButtonElement>('button')!.focus();
 		await nextFrame();
 		expect(el.shadowRoot!.querySelector('cosmoz-dropdown-content')).to.be.ok;
+	});
+
+	it('keeps dropdown content in DOM when closed', async () => {
+		const el = await fixture(
+			html`<cosmoz-dropdown><a href="#">Test<a/></cosmoz-dropdown>`,
+		);
+		const button = el.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
+		button.focus();
+		await nextFrame();
+
+		const content = el.shadowRoot!.querySelector<HTMLElement>(
+			'cosmoz-dropdown-content',
+		)!;
+		// Popover should be open when active/focused
+		expect(content.matches(':popover-open')).to.equal(true);
+
+		button.blur();
+		await nextFrame();
+
+		// Content should still be the same element (not re-created)
+		expect(el.shadowRoot!.querySelector('cosmoz-dropdown-content')).to.equal(
+			content,
+		);
+		// Popover should be closed but content still in DOM
+		expect(content.matches(':popover-open')).to.equal(false);
+	});
+
+	it('does not intercept Escape from an open dialog', async () => {
+		const el = await fixture(html`
+			<cosmoz-dropdown>
+				<dialog open>Dialog</dialog>
+			</cosmoz-dropdown>
+		`);
+		const button = el.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
+		const dialog = el.querySelector('dialog')!;
+
+		button.focus();
+		await nextFrame();
+
+		const event = new KeyboardEvent('keydown', {
+			key: 'Escape',
+			bubbles: true,
+			composed: true,
+			cancelable: true,
+		});
+		dialog.dispatchEvent(event);
+		await nextFrame();
+
+		expect(event.defaultPrevented).to.equal(false);
+		// Dropdown should stay open (popover still showing)
+		expect(
+			el
+				.shadowRoot!.querySelector<HTMLElement>('cosmoz-dropdown-content')!
+				.matches(':popover-open'),
+		).to.equal(true);
+	});
+
+	it('closes dropdown on Escape when not inside dialog', async () => {
+		const el = await fixture(
+			html`<cosmoz-dropdown><a href="#">Test<a/></cosmoz-dropdown>`,
+		);
+		const button = el.shadowRoot!.querySelector<HTMLButtonElement>('button')!;
+
+		button.focus();
+		await nextFrame();
+
+		const event = new KeyboardEvent('keydown', {
+			key: 'Escape',
+			bubbles: true,
+			composed: true,
+			cancelable: true,
+		});
+		document.dispatchEvent(event);
+		await nextFrame();
+
+		expect(event.defaultPrevented).to.equal(true);
+		// Dropdown should be closed (popover not showing)
+		expect(
+			el
+				.shadowRoot!.querySelector<HTMLElement>('cosmoz-dropdown-content')!
+				.matches(':popover-open'),
+		).to.equal(false);
 	});
 });


### PR DESCRIPTION
## Summary
- yield Escape handling to native open dialogs so modal dialog close is not blocked by the dropdown capture listener
- keep dropdown content mounted and toggle it with `hidden` while syncing the popover state, so slotted actions stay connected when the dropdown closes
- add regression coverage for dialog Escape behavior, closed-content preservation, and configure `beta` as an explicit prerelease branch for semantic-release

## Validation
- npm run lint
- npm test