### PR TITLE
fix: handle Chrome 149 :focus-within top-layer boundary and focusout race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,11 @@
 			"devDependencies": {
 				"@commitlint/cli": "^20.0.0",
 				"@commitlint/config-conventional": "^20.0.0",
-				"@neovici/cfg": "^2.8.0",
+				"@neovici/cfg": "^2.13.0",
 				"@neovici/cosmoz-button": "^1.0.0",
 				"@neovici/cosmoz-tokens": "^3.2.1",
 				"@open-wc/testing": "^4.0.0",
+				"@playwright/test": "1.60.0",
 				"@semantic-release/changelog": "^6.0.0",
 				"@semantic-release/git": "^10.0.0",
 				"@storybook/addon-docs": "^10.0.0",
@@ -1256,9 +1257,9 @@
 			}
 		},
 		"node_modules/@neovici/cfg": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.8.1.tgz",
-			"integrity": "sha512-oAr8c6HMUDOJ0PK4UBT31nKEu0pfJsI1rxt7JY6ufVjEKrAH7XTTxxChhP/9NrTQwt7ucUNYbl30S+y4P548bw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.13.0.tgz",
+			"integrity": "sha512-D/D2IE41CQFfbHH6tQgKx8nuDxNydqPUIW1OuLiwyp/96I80NRjFOkbznHJIT450Uf1WD2ehNNjcRc1x8Z+fpg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1280,11 +1281,25 @@
 				"globals": "^17.0.0",
 				"prettier": "^3.0.0",
 				"prettier-plugin-organize-imports": "^4.3.0",
-				"typescript": "^5.1.0",
+				"typescript": "^6.0.2",
 				"typescript-eslint": "^8.53.0"
 			},
 			"bin": {
 				"check-duplicate-components": "check-duplicate-components.mjs"
+			}
+		},
+		"node_modules/@neovici/cfg/node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@neovici/cosmoz-button": {
@@ -1578,48 +1593,16 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-			"integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@playwright/test/node_modules/playwright": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-			"integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.58.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@playwright/test/node_modules/playwright-core": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-			"integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
 			},
 			"engines": {
 				"node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"http-server": "^14.1.1",
 				"husky": "^9.0.11",
 				"lint-staged": "^16.2.7",
+				"playwright": "1.60.0",
 				"rollup-plugin-esbuild": "^6.1.1",
 				"semantic-release": "^25.0.0",
 				"shadow-dom-testing-library": "^1.13.1",
@@ -130,6 +131,7 @@
 			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1370,7 +1372,6 @@
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -1587,6 +1588,38 @@
 			},
 			"bin": {
 				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@playwright/test/node_modules/playwright": {
+			"version": "1.58.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+			"integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.58.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/@playwright/test/node_modules/playwright-core": {
+			"version": "1.58.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+			"integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3024,7 +3057,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/babel__code-frame": {
 			"version": "7.27.0",
@@ -3271,7 +3305,6 @@
 			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -3443,7 +3476,6 @@
 			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.54.0",
 				"@typescript-eslint/types": "8.54.0",
@@ -3930,7 +3962,6 @@
 			"integrity": "sha512-gVQqh7paBz3gC+ZdcCmNSWJMk70IUjDeVqi+5m5vYpEHsIwRgw3Y545jljtajhkekIpIp5Gg8oK7bctgY0E2Ng==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/mocker": "4.0.18",
 				"@vitest/utils": "4.0.18",
@@ -3954,7 +3985,6 @@
 			"integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/browser": "4.0.18",
 				"@vitest/mocker": "4.0.18",
@@ -4136,7 +4166,6 @@
 			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.0.18",
 				"pathe": "^2.0.3"
@@ -4545,7 +4574,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5993,7 +6021,6 @@
 			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -6089,7 +6116,8 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dargs": {
 			"version": "8.1.0",
@@ -6394,8 +6422,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
 			"integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
 			"version": "5.2.2",
@@ -6438,7 +6465,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
@@ -6965,7 +6993,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -7070,7 +7097,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7283,7 +7309,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -9917,7 +9942,6 @@
 			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@lit/reactive-element": "^2.1.0",
 				"lit-element": "^4.2.0",
@@ -10184,6 +10208,7 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -10280,7 +10305,6 @@
 			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -12674,7 +12698,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -13488,14 +13511,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-			"integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.58.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -13508,9 +13530,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-			"integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -13599,7 +13621,6 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -13633,6 +13654,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -13648,6 +13670,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -13658,6 +13681,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -13927,7 +13951,6 @@
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13938,7 +13961,6 @@
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -13951,7 +13973,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/read-package-up": {
 			"version": "12.0.0",
@@ -14362,7 +14385,6 @@
 			"integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -14548,7 +14570,6 @@
 			"integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^13.0.1",
 				"@semantic-release/error": "^4.0.0",
@@ -15438,7 +15459,6 @@
 			"integrity": "sha512-5UY1f0f4TCAmJ19DCvYmWbvZaYwszIOY+PxTzu0S/WJpqm4pzO0bjn6Wfx113Jnh/tffUZ3MVuQgjJq20/ttNg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@storybook/global": "^5.0.0",
 				"@storybook/icons": "^2.0.1",
@@ -16009,7 +16029,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -16300,7 +16319,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -16564,7 +16582,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -16669,7 +16686,6 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -17262,7 +17278,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -17276,7 +17291,6 @@
 			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.0.18",
 				"@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -83,10 +83,11 @@
 	"devDependencies": {
 		"@commitlint/cli": "^20.0.0",
 		"@commitlint/config-conventional": "^20.0.0",
-		"@neovici/cfg": "^2.8.0",
+		"@neovici/cfg": "^2.13.0",
 		"@neovici/cosmoz-button": "^1.0.0",
 		"@neovici/cosmoz-tokens": "^3.2.1",
 		"@open-wc/testing": "^4.0.0",
+		"@playwright/test": "1.60.0",
 		"@semantic-release/changelog": "^6.0.0",
 		"@semantic-release/git": "^10.0.0",
 		"@storybook/addon-docs": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"http-server": "^14.1.1",
 		"husky": "^9.0.11",
 		"lint-staged": "^16.2.7",
+		"playwright": "1.60.0",
 		"rollup-plugin-esbuild": "^6.1.1",
 		"semantic-release": "^25.0.0",
 		"shadow-dom-testing-library": "^1.13.1",

--- a/src/use-focus.ts
+++ b/src/use-focus.ts
@@ -1,7 +1,13 @@
-import { useEffect, useState, useCallback } from '@pionjs/pion';
 import { useMeta } from '@neovici/cosmoz-utils/hooks/use-meta';
+import { useCallback, useEffect, useRef, useState } from '@pionjs/pion';
 
-const isFocused = (t: Element) => t.matches(':focus-within');
+const isFocused = (t: Element) => {
+	if (t.matches(':focus-within')) {
+		return true;
+	}
+	const popover = t.shadowRoot?.querySelector('[popover]');
+	return popover?.matches(':focus-within') ?? false;
+};
 
 interface FocusState {
 	focused?: boolean;
@@ -64,18 +70,38 @@ export const useFocus = ({ disabled, onFocus }: UseFocusOpts) => {
 	};
 };
 
-const fevs = ['focusin', 'focusout'] as const;
 export const useHostFocus = (host: HTMLElement & UseFocusOpts) => {
 	const thru = useFocus(host),
 		{ onFocus } = thru;
 
+	const scheduleRef = useRef<ReturnType<typeof setTimeout>>();
+
 	useEffect(() => {
 		host.setAttribute('tabindex', '0');
-		fevs.forEach((ev) => host.addEventListener(ev, onFocus));
-		return () => {
-			fevs.forEach((ev) => host.removeEventListener(ev, onFocus));
+
+		const onFocusIn = (e: FocusEvent) => {
+			clearTimeout(scheduleRef.current);
+			onFocus(e);
 		};
-	}, []);
+
+		const onFocusOut = (e: FocusEvent) => {
+			clearTimeout(scheduleRef.current);
+			const currentTarget = e.currentTarget as HTMLElement;
+			// TODO: `onFocus` only uses `e.currentTarget`, consider refactoring to accept `HTMLElement` instead of `FocusEvent`
+			scheduleRef.current = setTimeout(
+				() => onFocus({ currentTarget } as unknown as FocusEvent),
+				30,
+			);
+		};
+
+		host.addEventListener('focusin', onFocusIn);
+		host.addEventListener('focusout', onFocusOut);
+		return () => {
+			clearTimeout(scheduleRef.current);
+			host.removeEventListener('focusin', onFocusIn);
+			host.removeEventListener('focusout', onFocusOut);
+		};
+	}, [onFocus]);
 
 	return thru;
 };


### PR DESCRIPTION
Chrome 149 shipped ["User action pseudo-class top layer boundary"](https://issues.chromium.org/issues/407769114) (also [Chrome 149 release notes](https://developer.chrome.com/release-notes/149)), which changes `:hover`, `:active`, and `:focus-within` to stop matching across top-layer boundaries.

Since `cosmoz-dropdown` content uses the `popover` attribute (a top-layer element), `:focus-within` no longer propagates from the popover content to the host element. This causes the dropdown to close spuriously when focus moves from the toggle button into the popover content (e.g. clicking a link inside the dropdown).

## Changes

### 1. `isFocused` now checks popover content `:focus-within`

```ts
const isFocused = (t: Element) => {
    if (t.matches(":focus-within")) {
        return true;
    }
    const popover = t.shadowRoot?.querySelector("[popover]");
    return popover?.matches(":focus-within") ?? false;
};
```

This matches the pattern already used in `cosmoz-dropdown-next`'s [`use-auto-open.ts`](src/next/use-auto-open.ts).

### 2. `useHostFocus` debounces `focusout` by 30ms

When focus moves within the dropdown (button → popover content), `focusout` fires before `focusin`. On Chrome 149, `isFocused` returns false at `focusout` time (because `:focus-within` doesn't cross the top-layer boundary yet), causing the dropdown to close immediately.

The fix:
- **`focusin`**: handled immediately (no change)
- **`focusout`**: debounced by 30ms — if `focusin` fires within that window, the pending close is cancelled

This matches the proven pattern in `cosmoz-dropdown-next`'s [`use-auto-open.ts`](src/next/use-auto-open.ts) which uses `scheduleClose` with a debounce.

### 3. Upgrade Playwright to 1.60.0

## Related

- [FE-787](https://linear.app/neovici/issue/FE-787/settings-page-cannot-be-opened-from-navigation) — Settings page cannot be opened from navigation