### PR TITLE
feat(next): add passthrough attribute to cosmoz-dropdown-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Modern dropdown using the Popover API and CSS Anchor Positioning.
 | Property        | Type      | Default               | Description                                                                                                              |
 | --------------- | --------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `placement`     | `string`  | `'bottom span-right'` | CSS anchor `position-area` value. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/position-area) for options. |
+| `disabled`      | `boolean` | `false`               | Prevents the dropdown from opening.                                                                                      |
+| `passthrough`   | `boolean` | `false`               | When `disabled` + `passthrough`, render default slot content inline instead of inside the popover.                       |
 | `open-on-hover` | `boolean` | `false`               | Open on pointer hover.                                                                                                   |
 | `open-on-focus` | `boolean` | `false`               | Open when the trigger receives focus.                                                                                    |
 
@@ -64,6 +66,24 @@ When auto-open is enabled:
 - The dropdown closes with a 100ms delay to allow moving between trigger and content
 - When `open-on-focus` is active, clicking the button only opens (does not toggle)
 - Otherwise, click works as a toggle
+
+#### Disabled + Passthrough
+
+When `disabled` and `passthrough` are both set, the default slot content renders in normal document flow (outside the popover). This enables using the dropdown as a conditional wrapper — popover mode when enabled, inline mode when disabled:
+
+```html
+<!-- Dropdown mode (enabled) -->
+<cosmoz-dropdown-next placement="bottom span-right">
+	<button slot="button">Menu</button>
+	<div>Popover content</div>
+</cosmoz-dropdown-next>
+
+<!-- Inline mode (disabled + passthrough) -->
+<cosmoz-dropdown-next disabled passthrough>
+	<button slot="button">Menu</button>
+	<div>Rendered inline, not inside a popover</div>
+</cosmoz-dropdown-next>
+```
 
 #### Slots
 

--- a/src/next/cosmoz-dropdown-next.ts
+++ b/src/next/cosmoz-dropdown-next.ts
@@ -100,6 +100,7 @@ interface DropdownProps {
 	placement?: string;
 	opened?: boolean;
 	disabled?: boolean;
+	passthrough?: boolean;
 	openOnHover?: boolean;
 	openOnFocus?: boolean;
 }
@@ -108,6 +109,7 @@ const CosmozDropdownNext = (host: HTMLElement & DropdownProps) => {
 	const {
 		placement = 'bottom span-right',
 		disabled,
+		passthrough,
 		openOnHover,
 		openOnFocus,
 	} = host;
@@ -173,17 +175,19 @@ const CosmozDropdownNext = (host: HTMLElement & DropdownProps) => {
 
 	return html`
 		<slot name="button" @click=${handleClick}></slot>
-		<div
-			popover
-			style="position-area: ${placement}"
-			@toggle=${onToggle}
-			@select=${close}
-			@focusout=${scheduleClose}
-			@focusin=${cancelClose}
-			${ref((el) => el && (popoverRef.current = el as HTMLElement))}
-		>
-			<slot></slot>
-		</div>
+		${disabled && passthrough
+			? html`<slot></slot>`
+			: html`<div
+					popover
+					style="position-area: ${placement}"
+					@toggle=${onToggle}
+					@select=${close}
+					@focusout=${scheduleClose}
+					@focusin=${cancelClose}
+					${ref((el) => el && (popoverRef.current = el as HTMLElement))}
+				>
+					<slot></slot>
+				</div>`}
 	`;
 };
 
@@ -194,6 +198,7 @@ customElements.define(
 		observedAttributes: [
 			'placement',
 			'disabled',
+			'passthrough',
 			'open-on-hover',
 			'open-on-focus',
 		],

--- a/stories/cosmoz-dropdown-next.stories.ts
+++ b/stories/cosmoz-dropdown-next.stories.ts
@@ -11,6 +11,7 @@ interface StoryArgs {
 	opened: boolean;
 	openOnHover: boolean;
 	openOnFocus: boolean;
+	passthrough: boolean;
 }
 
 const meta: Meta<StoryArgs> = {
@@ -37,12 +38,18 @@ const meta: Meta<StoryArgs> = {
 			control: 'boolean',
 			description: 'Open dropdown when the trigger receives focus.',
 		},
+		passthrough: {
+			control: 'boolean',
+			description:
+				'When disabled + passthrough, render default slot content in normal document flow instead of inside the popover.',
+		},
 	},
 	args: {
 		placement: 'bottom span-right',
 		opened: false,
 		openOnHover: false,
 		openOnFocus: false,
+		passthrough: false,
 	},
 };
 
@@ -364,6 +371,51 @@ export const DisabledFocusMode: Story = {
 			input.focus();
 			await new Promise((r) => setTimeout(r, 200));
 			expect(getPopover()?.matches(':popover-open')).toBe(false);
+		});
+	},
+};
+
+/**
+ * When `disabled` + `passthrough` are both set, the default slot content
+ * renders in normal document flow (outside the popover), making it visible
+ * even though the dropdown is disabled. This enables using the dropdown as
+ * a conditional wrapper — popover mode when enabled, inline mode when disabled.
+ */
+export const Passthrough: Story = {
+	args: {
+		passthrough: true,
+	},
+	render: (args) => html`
+		<cosmoz-dropdown-next
+			placement=${args.placement}
+			disabled
+			?passthrough=${args.passthrough}
+		>
+			<cosmoz-button slot="button">Toggle</cosmoz-button>
+			<div class="dropdown-content">
+				<div>Item 1</div>
+				<div>Item 2</div>
+				<div>Item 3</div>
+			</div>
+		</cosmoz-dropdown-next>
+	`,
+	play: async ({ canvasElement, step }) => {
+		const dropdown = canvasElement.querySelector(
+			'cosmoz-dropdown-next',
+		) as HTMLElement;
+
+		await step('No popover element in shadow DOM', async () => {
+			const popover = dropdown.shadowRoot!.querySelector('[popover]');
+			expect(popover).toBeNull();
+		});
+
+		await step('Default slot content is visible in normal flow', async () => {
+			const slot = dropdown.shadowRoot!.querySelector('slot:not([name])');
+			expect(slot).toBeTruthy();
+			const assigned = (slot as HTMLSlotElement).assignedElements({
+				flatten: true,
+			});
+			expect(assigned.length).toBeGreaterThan(0);
 		});
 	},
 };

--- a/stories/cosmoz-dropdown-next.stories.ts
+++ b/stories/cosmoz-dropdown-next.stories.ts
@@ -9,6 +9,7 @@ import { placementOptions } from './story-helpers';
 interface StoryArgs {
 	placement: string;
 	opened: boolean;
+	disabled: boolean;
 	openOnHover: boolean;
 	openOnFocus: boolean;
 	passthrough: boolean;
@@ -30,6 +31,10 @@ const meta: Meta<StoryArgs> = {
 			description:
 				'Get/set the dropdown open state. Reflected as an attribute.',
 		},
+		disabled: {
+			control: 'boolean',
+			description: 'Prevents the dropdown from opening.',
+		},
 		openOnHover: {
 			control: 'boolean',
 			description: 'Open dropdown on hover.',
@@ -47,6 +52,7 @@ const meta: Meta<StoryArgs> = {
 	args: {
 		placement: 'bottom span-right',
 		opened: false,
+		disabled: false,
 		openOnHover: false,
 		openOnFocus: false,
 		passthrough: false,
@@ -65,8 +71,10 @@ const renderDropdown = (
 	<cosmoz-dropdown-next
 		placement=${args.placement}
 		.opened=${args.opened}
+		?disabled=${args.disabled}
 		?open-on-hover=${args.openOnHover}
 		?open-on-focus=${args.openOnFocus}
+		?passthrough=${args.passthrough}
 	>
 		<cosmoz-button slot="button">${buttonLabel}</cosmoz-button>
 		${content}
@@ -296,10 +304,13 @@ export const FocusModeInput: Story = {
  * Disabled state prevents the dropdown from opening via click, focus, or hover.
  */
 export const Disabled: Story = {
+	args: {
+		disabled: true,
+	},
 	render: (args) => html`
 		<cosmoz-dropdown-next
 			placement=${args.placement}
-			disabled
+			?disabled=${args.disabled}
 			?open-on-focus=${args.openOnFocus}
 		>
 			<cosmoz-button slot="button">Disabled</cosmoz-button>
@@ -338,12 +349,13 @@ export const Disabled: Story = {
  */
 export const DisabledFocusMode: Story = {
 	args: {
+		disabled: true,
 		openOnFocus: true,
 	},
 	render: (args) => html`
 		<cosmoz-dropdown-next
 			placement=${args.placement}
-			disabled
+			?disabled=${args.disabled}
 			?open-on-focus=${args.openOnFocus}
 		>
 			<input slot="button" type="text" placeholder="Disabled input..." />
@@ -383,12 +395,13 @@ export const DisabledFocusMode: Story = {
  */
 export const Passthrough: Story = {
 	args: {
+		disabled: true,
 		passthrough: true,
 	},
 	render: (args) => html`
 		<cosmoz-dropdown-next
 			placement=${args.placement}
-			disabled
+			?disabled=${args.disabled}
 			?passthrough=${args.passthrough}
 		>
 			<cosmoz-button slot="button">Toggle</cosmoz-button>

--- a/stories/tests/cosmoz-dropdown-next.stories.ts
+++ b/stories/tests/cosmoz-dropdown-next.stories.ts
@@ -423,3 +423,87 @@ export const FocusBlurClose: Story = {
 		});
 	},
 };
+
+/**
+ * Verifies that when `disabled` + `passthrough` are both set, the default
+ * slot renders in normal document flow — no popover element exists in the
+ * shadow DOM, and the slotted content is visible.
+ */
+export const PassthroughRendersInline: Story = {
+	render: (args) => html`
+		<cosmoz-dropdown-next placement=${args.placement} disabled passthrough>
+			<cosmoz-button slot="button">Toggle</cosmoz-button>
+			<div class="dropdown-content">
+				<div>Item 1</div>
+				<div>Item 2</div>
+			</div>
+		</cosmoz-dropdown-next>
+	`,
+	play: async ({ canvasElement, step }) => {
+		const dropdown = canvasElement.querySelector(
+			'cosmoz-dropdown-next',
+		) as HTMLElement;
+
+		await step('No popover element in shadow DOM', async () => {
+			const popover = dropdown.shadowRoot!.querySelector('[popover]');
+			expect(popover).toBeNull();
+		});
+
+		await step('Default slot is rendered inline', async () => {
+			const slot = dropdown.shadowRoot!.querySelector('slot:not([name])');
+			expect(slot).toBeTruthy();
+			expect(slot!.closest('[popover]')).toBeNull();
+		});
+
+		await step('Slotted content is visible', async () => {
+			const slot = dropdown.shadowRoot!.querySelector(
+				'slot:not([name])',
+			) as HTMLSlotElement;
+			const assigned = slot.assignedElements({ flatten: true });
+			expect(assigned.length).toBeGreaterThan(0);
+		});
+	},
+};
+
+/**
+ * Verifies that `passthrough` without `disabled` has no effect — the popover
+ * element is still rendered and the dropdown behaves normally.
+ */
+export const PassthroughWithoutDisabled: Story = {
+	render: (args) => html`
+		<cosmoz-dropdown-next placement=${args.placement} passthrough>
+			<cosmoz-button slot="button">Toggle</cosmoz-button>
+			<div class="dropdown-content">
+				<div>Item 1</div>
+			</div>
+		</cosmoz-dropdown-next>
+	`,
+	play: async ({ canvasElement, step }) => {
+		const dropdown = canvasElement.querySelector(
+			'cosmoz-dropdown-next',
+		) as HTMLElement & { opened: boolean };
+		const button = dropdown.querySelector('[slot="button"]') as HTMLElement;
+
+		await step(
+			'Popover element exists (passthrough without disabled has no effect)',
+			async () => {
+				const popover = dropdown.shadowRoot!.querySelector('[popover]');
+				expect(popover).toBeTruthy();
+			},
+		);
+
+		await step('Click toggles popover normally', async () => {
+			await userEvent.click(button);
+			await waitFor(() => {
+				expect(getPopover(dropdown)?.matches(':popover-open')).toBe(true);
+			});
+		});
+
+		await step('Click closes popover normally', async () => {
+			await userEvent.click(button);
+			await waitFor(() => {
+				expect(getPopover(dropdown)?.matches(':popover-open')).toBe(false);
+			});
+		});
+	},
+};


### PR DESCRIPTION
## Summary

Adds a `passthrough` boolean attribute to `cosmoz-dropdown-next`.

When both `disabled` and `passthrough` are set, the default `<slot>` renders in normal document flow (outside the popover `<div>`), instead of being trapped inside the hidden popover. This enables using the dropdown as a conditional wrapper — popover mode when enabled, inline mode when disabled.

### Changes
- Add `passthrough` to `DropdownProps` interface and destructure from host
- Conditionally render `<slot>` inline when `disabled && passthrough`
- Add `'passthrough'` to `observedAttributes`
- Add `Passthrough` story with play function verification
- Add `PassthroughRendersInline` and `PassthroughWithoutDisabled` test stories

Closes FE-809