### PR TITLE
fix: guard showPopover/hidePopover calls with optional chaining

### DIFF
--- a/src/next/cosmoz-dropdown-next.ts
+++ b/src/next/cosmoz-dropdown-next.ts
@@ -122,11 +122,11 @@ const CosmozDropdownNext = (host: HTMLElement & DropdownProps) => {
 	const open = useCallback(() => {
 		if (disabled) return;
 		setOpened(true);
-		popoverRef.current?.showPopover();
+		popoverRef.current?.showPopover?.();
 	}, [disabled]);
 	const close = useCallback(() => {
 		setOpened(false);
-		popoverRef.current?.hidePopover();
+		popoverRef.current?.hidePopover?.();
 	}, []);
 	const toggle = useCallback(() => {
 		if (disabled) return;
@@ -139,8 +139,8 @@ const CosmozDropdownNext = (host: HTMLElement & DropdownProps) => {
 	useEffect(() => {
 		const popover = popoverRef.current;
 		if (!popover) return;
-		if (opened) popover.showPopover();
-		else popover.hidePopover();
+		if (opened) popover.showPopover?.();
+		else popover.hidePopover?.();
 	}, [opened]);
 
 	useEffect(() => {

--- a/stories/tests/cosmoz-dropdown-next.stories.ts
+++ b/stories/tests/cosmoz-dropdown-next.stories.ts
@@ -147,7 +147,7 @@ export const NativeCloseSyncsProperty: Story = {
 				// Simulate browser-initiated close (light-dismiss / Escape).
 				// hidePopover() fires the native toggle event, same as
 				// light-dismiss and Escape key.
-				getPopover(dropdown)!.hidePopover();
+				getPopover(dropdown)!.hidePopover?.();
 				await waitFor(() => {
 					expect(getPopover(dropdown)?.matches(':popover-open')).toBe(false);
 					expect(dropdown.opened).toBe(false);


### PR DESCRIPTION
## Problem

`showPopover()` and `hidePopover()` are called directly on DOM elements without feature detection. On browsers without Popover API support (Chrome < 114, Edge < 114, Safari < 17, Firefox < 125), these throw `TypeError: ... is not a function`, causing **411 browser exceptions per 24h** in production.

## Fix

Use optional chaining on the method itself (`?.()`) at all 4 call sites so calls silently no-op instead of throwing when the Popover API is unavailable:

- `popoverRef.current?.showPopover?.()` (was `popoverRef.current?.showPopover()`)
- `popoverRef.current?.hidePopover?.()` (was `popoverRef.current?.hidePopover()`)
- `popover.showPopover?.()` (was `popover.showPopover()`)
- `popover.hidePopover?.()` (was `popover.hidePopover()`)

Also guarded the test file's direct `hidePopover()` call for consistency.

This matches the pattern already used in the non-next `cosmoz-dropdown.ts` (line 66).

Fixes FE-936