### PR TITLE
chore: add changeset for FE-936 popover optional chaining fix

### DIFF
--- a/.changeset/fe-936-popover-optional-chaining.md
+++ b/.changeset/fe-936-popover-optional-chaining.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-dropdown': patch
+---
+
+Guard `showPopover`/`hidePopover` calls with optional chaining to prevent crashes on browsers without Popover API support (Chrome < 114, Edge < 114, Safari < 17, Firefox < 125).


### PR DESCRIPTION
Adds the missing changeset for the merged PR #62 (FE-936).

Patch-level bump for guarding `showPopover`/`hidePopover` calls with optional chaining to prevent crashes on browsers without Popover API support.