### PR TITLE
[ci] release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,472 +1,439 @@
+## [7.7.1](https://github.com/Neovici/cosmoz-dropdown/compare/v7.7.0...v7.7.1) (2026-07-10)
+
+### Patch Changes
+
+- Guard `showPopover`/`hidePopover` calls with optional chaining to prevent crashes on browsers without Popover API support (Chrome < 114, Edge < 114, Safari < 17, Firefox < 125)
+- Migrate from semantic-release to changesets
+
 ## [7.7.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.6.1...v7.7.0) (2026-06-13)
 
 ### Features
 
-* **next:** add passthrough attribute to cosmoz-dropdown-next ([#59](https://github.com/Neovici/cosmoz-dropdown/issues/59)) ([3b50921](https://github.com/Neovici/cosmoz-dropdown/commit/3b50921401a7b7dfc0194c76f5d7aed929752ea8))
+- **next:** add passthrough attribute to cosmoz-dropdown-next ([#59](https://github.com/Neovici/cosmoz-dropdown/issues/59)) ([3b50921](https://github.com/Neovici/cosmoz-dropdown/commit/3b50921401a7b7dfc0194c76f5d7aed929752ea8))
 
 ## [7.6.1](https://github.com/Neovici/cosmoz-dropdown/compare/v7.6.0...v7.6.1) (2026-06-08)
 
 ### Bug Fixes
 
-* handle Chrome 149 :focus-within top-layer boundary and focusout race ([#58](https://github.com/Neovici/cosmoz-dropdown/issues/58)) ([6f8128e](https://github.com/Neovici/cosmoz-dropdown/commit/6f8128eed95c17e1262a5ecdce8896b3310c5b39))
+- handle Chrome 149 :focus-within top-layer boundary and focusout race ([#58](https://github.com/Neovici/cosmoz-dropdown/issues/58)) ([6f8128e](https://github.com/Neovici/cosmoz-dropdown/commit/6f8128eed95c17e1262a5ecdce8896b3310c5b39))
 
 ## [7.6.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.5.0...v7.6.0) (2026-04-07)
 
 ### Features
 
-* inline offset removed ([#56](https://github.com/Neovici/cosmoz-dropdown/issues/56)) ([b45779a](https://github.com/Neovici/cosmoz-dropdown/commit/b45779a30754fdb230eced70787240d9673688f1))
+- inline offset removed ([#56](https://github.com/Neovici/cosmoz-dropdown/issues/56)) ([b45779a](https://github.com/Neovici/cosmoz-dropdown/commit/b45779a30754fdb230eced70787240d9673688f1))
 
 ## [7.5.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.4.2...v7.5.0) (2026-02-19)
 
 ### Features
 
-* add disabled support to cosmoz-dropdown-next ([#55](https://github.com/Neovici/cosmoz-dropdown/issues/55)) ([ce6a60b](https://github.com/Neovici/cosmoz-dropdown/commit/ce6a60ba21eab494ce25b6cac94d3f4f590a2080))
+- add disabled support to cosmoz-dropdown-next ([#55](https://github.com/Neovici/cosmoz-dropdown/issues/55)) ([ce6a60b](https://github.com/Neovici/cosmoz-dropdown/commit/ce6a60ba21eab494ce25b6cac94d3f4f590a2080))
 
 ## [7.4.2](https://github.com/Neovici/cosmoz-dropdown/compare/v7.4.1...v7.4.2) (2026-02-17)
 
 ### Bug Fixes
 
-* **dropdown-next:** close popover on focusout ([#52](https://github.com/Neovici/cosmoz-dropdown/issues/52)) ([cb9ca7c](https://github.com/Neovici/cosmoz-dropdown/commit/cb9ca7c66628b576b1c5d8e7f461f8d4ea2915c2))
+- **dropdown-next:** close popover on focusout ([#52](https://github.com/Neovici/cosmoz-dropdown/issues/52)) ([cb9ca7c](https://github.com/Neovici/cosmoz-dropdown/commit/cb9ca7c66628b576b1c5d8e7f461f8d4ea2915c2))
 
 ## [7.4.1](https://github.com/Neovici/cosmoz-dropdown/compare/v7.4.0...v7.4.1) (2026-02-16)
 
 ### Bug Fixes
 
-* **dropdown-next:** call showPopover/hidePopover synchronously in open/close/toggle ([#54](https://github.com/Neovici/cosmoz-dropdown/issues/54)) ([a35618a](https://github.com/Neovici/cosmoz-dropdown/commit/a35618af05165aca52eb59a5f56ad4a9241a7dcc))
+- **dropdown-next:** call showPopover/hidePopover synchronously in open/close/toggle ([#54](https://github.com/Neovici/cosmoz-dropdown/issues/54)) ([a35618a](https://github.com/Neovici/cosmoz-dropdown/commit/a35618af05165aca52eb59a5f56ad4a9241a7dcc))
 
 ## [7.4.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.3.0...v7.4.0) (2026-02-16)
 
 ### Features
 
-* **dropdown-next:** add opened property with attribute reflection ([#53](https://github.com/Neovici/cosmoz-dropdown/issues/53)) ([3933c28](https://github.com/Neovici/cosmoz-dropdown/commit/3933c285dca9e2343be0903ee9b38fe28ca350cc))
+- **dropdown-next:** add opened property with attribute reflection ([#53](https://github.com/Neovici/cosmoz-dropdown/issues/53)) ([3933c28](https://github.com/Neovici/cosmoz-dropdown/commit/3933c285dca9e2343be0903ee9b38fe28ca350cc))
 
 ## [7.3.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.2.0...v7.3.0) (2026-02-10)
 
 ### Features
 
-* **dropdown-next:** re-dispatch toggle event as composed, fix click race ([#49](https://github.com/Neovici/cosmoz-dropdown/issues/49)) ([ecd8814](https://github.com/Neovici/cosmoz-dropdown/commit/ecd881426daf139e1158b031a87c3e4bb57fc94e))
-* **dropdown-next:** set popover min-width to anchor width ([#51](https://github.com/Neovici/cosmoz-dropdown/issues/51)) ([b44e312](https://github.com/Neovici/cosmoz-dropdown/commit/b44e3122110c40fcc94f2717e1e643dfc67c450c))
+- **dropdown-next:** re-dispatch toggle event as composed, fix click race ([#49](https://github.com/Neovici/cosmoz-dropdown/issues/49)) ([ecd8814](https://github.com/Neovici/cosmoz-dropdown/commit/ecd881426daf139e1158b031a87c3e4bb57fc94e))
+- **dropdown-next:** set popover min-width to anchor width ([#51](https://github.com/Neovici/cosmoz-dropdown/issues/51)) ([b44e312](https://github.com/Neovici/cosmoz-dropdown/commit/b44e3122110c40fcc94f2717e1e643dfc67c450c))
 
 ## [7.2.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.1.0...v7.2.0) (2026-02-06)
 
 ### Features
 
-* **dropdown-next:** add open-on-hover and open-on-focus props ([#47](https://github.com/Neovici/cosmoz-dropdown/issues/47)) ([0b8bb15](https://github.com/Neovici/cosmoz-dropdown/commit/0b8bb15387e435708413975a65ae6bcd2b2ce8ea))
+- **dropdown-next:** add open-on-hover and open-on-focus props ([#47](https://github.com/Neovici/cosmoz-dropdown/issues/47)) ([0b8bb15](https://github.com/Neovici/cosmoz-dropdown/commit/0b8bb15387e435708413975a65ae6bcd2b2ce8ea))
 
 ## [7.1.0](https://github.com/Neovici/cosmoz-dropdown/compare/v7.0.2...v7.1.0) (2026-02-03)
 
 ### Features
 
-* cosmoz-dropdown-next with Popover API and CSS Anchor Positioning ([#46](https://github.com/Neovici/cosmoz-dropdown/issues/46)) ([882faf4](https://github.com/Neovici/cosmoz-dropdown/commit/882faf4073afc5557bf2799d3153e0370e5ecd35)), closes [whatwg/html#9245](https://github.com/whatwg/html/issues/9245)
+- cosmoz-dropdown-next with Popover API and CSS Anchor Positioning ([#46](https://github.com/Neovici/cosmoz-dropdown/issues/46)) ([882faf4](https://github.com/Neovici/cosmoz-dropdown/commit/882faf4073afc5557bf2799d3153e0370e5ecd35)), closes [whatwg/html#9245](https://github.com/whatwg/html/issues/9245)
 
 ## [7.0.2](https://github.com/Neovici/cosmoz-dropdown/compare/v7.0.1...v7.0.2) (2026-01-30)
 
 ### Bug Fixes
 
-* reset default button styles ([#45](https://github.com/Neovici/cosmoz-dropdown/issues/45)) ([f2f456c](https://github.com/Neovici/cosmoz-dropdown/commit/f2f456c28fed03d8d9aa6652dea3705b00ff8cae))
+- reset default button styles ([#45](https://github.com/Neovici/cosmoz-dropdown/issues/45)) ([f2f456c](https://github.com/Neovici/cosmoz-dropdown/commit/f2f456c28fed03d8d9aa6652dea3705b00ff8cae))
 
 ## [7.0.1](https://github.com/Neovici/cosmoz-dropdown/compare/v7.0.0...v7.0.1) (2026-01-27)
 
 ### Bug Fixes
 
-* repository URL case sensitivity ([f1d3050](https://github.com/Neovici/cosmoz-dropdown/commit/f1d30508fab5f5deea043c662518610ed2a9dd3f))
+- repository URL case sensitivity ([f1d3050](https://github.com/Neovici/cosmoz-dropdown/commit/f1d30508fab5f5deea043c662518610ed2a9dd3f))
 
 ## [7.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.5.0...v7.0.0) (2026-01-26)
 
 ### ⚠ BREAKING CHANGES
 
-* button styling removed
+- button styling removed
 
 ### Features
 
-* remove default button styling ([#43](https://github.com/neovici/cosmoz-dropdown/issues/43)) ([acdb1c0](https://github.com/neovici/cosmoz-dropdown/commit/acdb1c0c2c2f1efb33fb7c99d5dd836b870e4477))
+- remove default button styling ([#43](https://github.com/neovici/cosmoz-dropdown/issues/43)) ([acdb1c0](https://github.com/neovici/cosmoz-dropdown/commit/acdb1c0c2c2f1efb33fb7c99d5dd836b870e4477))
 
 ### Bug Fixes
 
-* release ([7907ae4](https://github.com/neovici/cosmoz-dropdown/commit/7907ae4c2c0dd1a96e0ab875572fcf6ac8c8f935))
+- release ([7907ae4](https://github.com/neovici/cosmoz-dropdown/commit/7907ae4c2c0dd1a96e0ab875572fcf6ac8c8f935))
 
 ## [6.5.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.4.0...v6.5.0) (2025-10-22)
 
 ### Features
 
-* update deps ([674e863](https://github.com/neovici/cosmoz-dropdown/commit/674e863ea9f63df245bdbd5eded612244b016633))
+- update deps ([674e863](https://github.com/neovici/cosmoz-dropdown/commit/674e863ea9f63df245bdbd5eded612244b016633))
 
 ## [6.4.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.3.0...v6.4.0) (2025-10-06)
 
 ### Features
 
-* color variables and border radius ([#40](https://github.com/neovici/cosmoz-dropdown/issues/40)) ([52a57f8](https://github.com/neovici/cosmoz-dropdown/commit/52a57f84c363857c0253376a38c98f12f9fdd686))
+- color variables and border radius ([#40](https://github.com/neovici/cosmoz-dropdown/issues/40)) ([52a57f8](https://github.com/neovici/cosmoz-dropdown/commit/52a57f84c363857c0253376a38c98f12f9fdd686))
 
 ## [6.3.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.2.1...v6.3.0) (2025-08-12)
 
 ### Features
 
-* **cosmoz-dropdown:** add variable for hover color ([3bca65d](https://github.com/neovici/cosmoz-dropdown/commit/3bca65d96584d0e74d5c0a83c363484df210ab9e))
+- **cosmoz-dropdown:** add variable for hover color ([3bca65d](https://github.com/neovici/cosmoz-dropdown/commit/3bca65d96584d0e74d5c0a83c363484df210ab9e))
 
 ### Bug Fixes
 
-* **dropdown:** dry ([ce4fb53](https://github.com/neovici/cosmoz-dropdown/commit/ce4fb53e0fcfafc8619c28b5b10b1a42acd97f07))
+- **dropdown:** dry ([ce4fb53](https://github.com/neovici/cosmoz-dropdown/commit/ce4fb53e0fcfafc8619c28b5b10b1a42acd97f07))
 
 ## [6.2.1](https://github.com/neovici/cosmoz-dropdown/compare/v6.2.0...v6.2.1) (2025-08-04)
 
 ### Bug Fixes
 
-* automerge workflow ([b9b7f82](https://github.com/neovici/cosmoz-dropdown/commit/b9b7f824140e46bae1d9bde023079b7c917f1cc2))
+- automerge workflow ([b9b7f82](https://github.com/neovici/cosmoz-dropdown/commit/b9b7f824140e46bae1d9bde023079b7c917f1cc2))
 
 ## [6.2.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.1.0...v6.2.0) (2025-07-21)
 
 ### Features
 
-* new automate workflow ([8465258](https://github.com/neovici/cosmoz-dropdown/commit/84652588d1c2704157e412a809b5ecfff2871d5c))
+- new automate workflow ([8465258](https://github.com/neovici/cosmoz-dropdown/commit/84652588d1c2704157e412a809b5ecfff2871d5c))
 
 ## [6.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v6.0.0...v6.1.0) (2025-02-14)
 
 ### Features
 
-* **use-floating:** separate reference and floating ([ab243b9](https://github.com/neovici/cosmoz-dropdown/commit/ab243b940f54edec2e6870fd600a35b77876a35e))
+- **use-floating:** separate reference and floating ([ab243b9](https://github.com/neovici/cosmoz-dropdown/commit/ab243b940f54edec2e6870fd600a35b77876a35e))
 
 ## [6.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v5.4.0...v6.0.0) (2025-02-07)
 
 ### ⚠ BREAKING CHANGES
 
-* Cleanup and remove usePosition and position.js module
+- Cleanup and remove usePosition and position.js module
 
 ### Code Refactoring
 
-* cleanup and remove usePosition ([9c4d0ca](https://github.com/neovici/cosmoz-dropdown/commit/9c4d0ca004a28de9f966a969425db1e15a9ff874))
+- cleanup and remove usePosition ([9c4d0ca](https://github.com/neovici/cosmoz-dropdown/commit/9c4d0ca004a28de9f966a969425db1e15a9ff874))
 
 ## [5.4.0](https://github.com/neovici/cosmoz-dropdown/compare/v5.3.0...v5.4.0) (2025-01-07)
 
 ### Features
 
-* **cosmoz-dropdown:** add middleware support ([1d479a0](https://github.com/neovici/cosmoz-dropdown/commit/1d479a020b2b856f8a1477ef2e8798676d8e1890))
+- **cosmoz-dropdown:** add middleware support ([1d479a0](https://github.com/neovici/cosmoz-dropdown/commit/1d479a020b2b856f8a1477ef2e8798676d8e1890))
 
 ## [5.3.0](https://github.com/neovici/cosmoz-dropdown/compare/v5.2.0...v5.3.0) (2024-12-30)
 
 ### Features
 
-* export floating-ui middlewares ([02d3883](https://github.com/neovici/cosmoz-dropdown/commit/02d38833e592adcd86651b5bec15bced74a0294c))
+- export floating-ui middlewares ([02d3883](https://github.com/neovici/cosmoz-dropdown/commit/02d38833e592adcd86651b5bec15bced74a0294c))
 
 ## [5.2.0](https://github.com/neovici/cosmoz-dropdown/compare/v5.1.0...v5.2.0) (2024-12-30)
 
 ### Features
 
-* **use-floating:** export defaultMiddleware ([f49fb44](https://github.com/neovici/cosmoz-dropdown/commit/f49fb4464809531ed52b7efa7f1f1eaf61905c92))
+- **use-floating:** export defaultMiddleware ([f49fb44](https://github.com/neovici/cosmoz-dropdown/commit/f49fb4464809531ed52b7efa7f1f1eaf61905c92))
 
 ## [5.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v5.0.0...v5.1.0) (2024-12-30)
 
 ### Features
 
-* more exports ([1a3f030](https://github.com/neovici/cosmoz-dropdown/commit/1a3f030901cb70281ef0fd3db585f99f0d2d0fd9))
+- more exports ([1a3f030](https://github.com/neovici/cosmoz-dropdown/commit/1a3f030901cb70281ef0fd3db585f99f0d2d0fd9))
 
 ## [5.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v4.4.2...v5.0.0) (2024-12-30)
 
 ### ⚠ BREAKING CHANGES
 
-* Implement  `floating-ui` (useFloating) integration
+- Implement `floating-ui` (useFloating) integration
 
 ### Features
 
-* implement floating-ui integration ([4154ea5](https://github.com/neovici/cosmoz-dropdown/commit/4154ea52611d9505924b83d9acf21813ac1f2b31))
-* refactor & implement connectable ([6a04b01](https://github.com/neovici/cosmoz-dropdown/commit/6a04b01f1085dafb91634c63f6edfec523c0950d))
+- implement floating-ui integration ([4154ea5](https://github.com/neovici/cosmoz-dropdown/commit/4154ea52611d9505924b83d9acf21813ac1f2b31))
+- refactor & implement connectable ([6a04b01](https://github.com/neovici/cosmoz-dropdown/commit/6a04b01f1085dafb91634c63f6edfec523c0950d))
 
 ## [4.4.2](https://github.com/neovici/cosmoz-dropdown/compare/v4.4.1...v4.4.2) (2024-10-04)
 
-
 ### Bug Fixes
 
-* **use-position:** add if rule when element end up outside viewport ([f36aced](https://github.com/neovici/cosmoz-dropdown/commit/f36acedeb5ffb6e944e3a39d079aec4a6c374ed2))
+- **use-position:** add if rule when element end up outside viewport ([f36aced](https://github.com/neovici/cosmoz-dropdown/commit/f36acedeb5ffb6e944e3a39d079aec4a6c374ed2))
 
 ## [4.4.1](https://github.com/neovici/cosmoz-dropdown/compare/v4.4.0...v4.4.1) (2024-05-02)
 
-
 ### Bug Fixes
 
-* remove the popover padding ([#24](https://github.com/neovici/cosmoz-dropdown/issues/24)) ([10c3437](https://github.com/neovici/cosmoz-dropdown/commit/10c3437e893fedb6101a57ac071e31c8fd957c8a))
+- remove the popover padding ([#24](https://github.com/neovici/cosmoz-dropdown/issues/24)) ([10c3437](https://github.com/neovici/cosmoz-dropdown/commit/10c3437e893fedb6101a57ac071e31c8fd957c8a))
 
 ## [4.4.0](https://github.com/neovici/cosmoz-dropdown/compare/v4.3.0...v4.4.0) (2024-04-10)
 
-
 ### Features
 
-* add requested changes ([2dd31de](https://github.com/neovici/cosmoz-dropdown/commit/2dd31de91748263da91cba79999e672e2257dccc))
-* move `popover` attribute ([7dcc348](https://github.com/neovici/cosmoz-dropdown/commit/7dcc34850cbda9cae3e3059632fba64ebbaceedd))
-* open dialog programmatically ([cb6c629](https://github.com/neovici/cosmoz-dropdown/commit/cb6c62972b3112c07527eb7dbc5b88bcf8932232))
-* rename story ([502fc28](https://github.com/neovici/cosmoz-dropdown/commit/502fc2853bcf747998630b3ca41d339436875667))
-* update story with bug ([6916618](https://github.com/neovici/cosmoz-dropdown/commit/6916618d1f60c0ddc1911da7f4cc83d1ded09d94))
-* use `:host(:popover-open)` selector ([5ecb921](https://github.com/neovici/cosmoz-dropdown/commit/5ecb92132c231d579b0fa05959c4f65d7bcfbe06))
-* use `popover` instead of `<dialog>` ([6620f87](https://github.com/neovici/cosmoz-dropdown/commit/6620f87e054fd20ccab484b278d28971c96f035b))
-
+- add requested changes ([2dd31de](https://github.com/neovici/cosmoz-dropdown/commit/2dd31de91748263da91cba79999e672e2257dccc))
+- move `popover` attribute ([7dcc348](https://github.com/neovici/cosmoz-dropdown/commit/7dcc34850cbda9cae3e3059632fba64ebbaceedd))
+- open dialog programmatically ([cb6c629](https://github.com/neovici/cosmoz-dropdown/commit/cb6c62972b3112c07527eb7dbc5b88bcf8932232))
+- rename story ([502fc28](https://github.com/neovici/cosmoz-dropdown/commit/502fc2853bcf747998630b3ca41d339436875667))
+- update story with bug ([6916618](https://github.com/neovici/cosmoz-dropdown/commit/6916618d1f60c0ddc1911da7f4cc83d1ded09d94))
+- use `:host(:popover-open)` selector ([5ecb921](https://github.com/neovici/cosmoz-dropdown/commit/5ecb92132c231d579b0fa05959c4f65d7bcfbe06))
+- use `popover` instead of `<dialog>` ([6620f87](https://github.com/neovici/cosmoz-dropdown/commit/6620f87e054fd20ccab484b278d28971c96f035b))
 
 ### Bug Fixes
 
-* show box shadow in Chrome ([e6605b5](https://github.com/neovici/cosmoz-dropdown/commit/e6605b5acf5e966cea58383bc538a410ef47bcca))
+- show box shadow in Chrome ([e6605b5](https://github.com/neovici/cosmoz-dropdown/commit/e6605b5acf5e966cea58383bc538a410ef47bcca))
 
 ## [4.3.0](https://github.com/neovici/cosmoz-dropdown/compare/v4.2.0...v4.3.0) (2024-04-05)
 
-
 ### Features
 
-* add DropdownWithBug story ([a4316c6](https://github.com/neovici/cosmoz-dropdown/commit/a4316c6dd82ab3754aa40afea2c1bd319c9c3851))
-
+- add DropdownWithBug story ([a4316c6](https://github.com/neovici/cosmoz-dropdown/commit/a4316c6dd82ab3754aa40afea2c1bd319c9c3851))
 
 ### Bug Fixes
 
-* make the storybook github workflow work ([b971cb8](https://github.com/neovici/cosmoz-dropdown/commit/b971cb886f5d389c4df2c97a948babbafb19cf5d))
+- make the storybook github workflow work ([b971cb8](https://github.com/neovici/cosmoz-dropdown/commit/b971cb886f5d389c4df2c97a948babbafb19cf5d))
 
 ## [4.2.0](https://github.com/neovici/cosmoz-dropdown/compare/v4.1.0...v4.2.0) (2024-04-04)
 
-
 ### Features
 
-* add storybook dependencies ([9807ca0](https://github.com/neovici/cosmoz-dropdown/commit/9807ca0967694339f6be44f3843a34610d80a2d3))
-* add storybook settings and stories ([64afb6c](https://github.com/neovici/cosmoz-dropdown/commit/64afb6c2a06b985636a3c939449e0cefafadd68f))
-* rezolve `IOptions` lint error ([2269eb3](https://github.com/neovici/cosmoz-dropdown/commit/2269eb37cf0734197513d3bd3f3bb284a578ee51))
+- add storybook dependencies ([9807ca0](https://github.com/neovici/cosmoz-dropdown/commit/9807ca0967694339f6be44f3843a34610d80a2d3))
+- add storybook settings and stories ([64afb6c](https://github.com/neovici/cosmoz-dropdown/commit/64afb6c2a06b985636a3c939449e0cefafadd68f))
+- rezolve `IOptions` lint error ([2269eb3](https://github.com/neovici/cosmoz-dropdown/commit/2269eb37cf0734197513d3bd3f3bb284a578ee51))
 
 ## [4.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v4.0.1...v4.1.0) (2024-04-04)
 
-
 ### Features
 
-* add storybook-static dir to .gitignore ([cbd108a](https://github.com/neovici/cosmoz-dropdown/commit/cbd108a6844953cacd1d72cfca4866e9cba2f6a4))
-* update dependencies ([d8d4732](https://github.com/neovici/cosmoz-dropdown/commit/d8d473269f34e237c9775ea3b37ed4eb0c6ebb32))
-* update semantic-release ([13d4706](https://github.com/neovici/cosmoz-dropdown/commit/13d4706774a0ad66d2c396df97f68c3c1baf802e))
+- add storybook-static dir to .gitignore ([cbd108a](https://github.com/neovici/cosmoz-dropdown/commit/cbd108a6844953cacd1d72cfca4866e9cba2f6a4))
+- update dependencies ([d8d4732](https://github.com/neovici/cosmoz-dropdown/commit/d8d473269f34e237c9775ea3b37ed4eb0c6ebb32))
+- update semantic-release ([13d4706](https://github.com/neovici/cosmoz-dropdown/commit/13d4706774a0ad66d2c396df97f68c3c1baf802e))
 
 ## [4.0.1](https://github.com/neovici/cosmoz-dropdown/compare/v4.0.0...v4.0.1) (2024-03-14)
 
-
 ### Bug Fixes
 
-* change button tabindex ([84a03a6](https://github.com/neovici/cosmoz-dropdown/commit/84a03a6cc599b0ed59f5b0b70b116bcad8a37bfa))
+- change button tabindex ([84a03a6](https://github.com/neovici/cosmoz-dropdown/commit/84a03a6cc599b0ed59f5b0b70b116bcad8a37bfa))
 
 ## [4.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v3.4.0...v4.0.0) (2024-01-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Update to @pionjs/pion
+- Update to @pionjs/pion
 
 ### Features
 
-* update to pion ([5504f65](https://github.com/neovici/cosmoz-dropdown/commit/5504f657667ace027fcba47c98e86f9faa5d6dbc))
+- update to pion ([5504f65](https://github.com/neovici/cosmoz-dropdown/commit/5504f657667ace027fcba47c98e86f9faa5d6dbc))
 
 ## [3.4.0](https://github.com/neovici/cosmoz-dropdown/compare/v3.3.0...v3.4.0) (2023-04-28)
 
-
 ### Features
 
-* **use-focus:** return focused & active ([60ea8ac](https://github.com/neovici/cosmoz-dropdown/commit/60ea8acce26e5cb0cd980c1c4cbb806ae9b53ba3))
+- **use-focus:** return focused & active ([60ea8ac](https://github.com/neovici/cosmoz-dropdown/commit/60ea8acce26e5cb0cd980c1c4cbb806ae9b53ba3))
 
 ## [3.3.0](https://github.com/neovici/cosmoz-dropdown/compare/v3.2.0...v3.3.0) (2023-03-31)
 
-
 ### Features
 
-* adjust types ([9f74ebe](https://github.com/neovici/cosmoz-dropdown/commit/9f74ebe104720f0059a447b93decacf6d2d3c375))
+- adjust types ([9f74ebe](https://github.com/neovici/cosmoz-dropdown/commit/9f74ebe104720f0059a447b93decacf6d2d3c375))
 
 ## [3.2.0](https://github.com/neovici/cosmoz-dropdown/compare/v3.1.0...v3.2.0) (2023-03-31)
 
-
 ### Features
 
-* add type def ([fabd9f8](https://github.com/neovici/cosmoz-dropdown/commit/fabd9f872904cdac0903cabc4946b840a21ef7bb))
+- add type def ([fabd9f8](https://github.com/neovici/cosmoz-dropdown/commit/fabd9f872904cdac0903cabc4946b840a21ef7bb))
 
 ## [3.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v3.0.2...v3.1.0) (2023-03-31)
 
-
 ### Features
 
-* add exports ([388c286](https://github.com/neovici/cosmoz-dropdown/commit/388c2863a9e20ae84bf501ced2cde4a0ac3925df))
-* adjust storybook ci ([d39ea01](https://github.com/neovici/cosmoz-dropdown/commit/d39ea01114afa32fbb9cced78a19b7661109d20c))
-* adjust tests ([9ae3943](https://github.com/neovici/cosmoz-dropdown/commit/9ae3943143b7b753278fc790c18b552388be11a0))
-* convert to ts ([c074f0e](https://github.com/neovici/cosmoz-dropdown/commit/c074f0e5cfd6bd4c992f8af4fa7945e12c880ba1))
-
+- add exports ([388c286](https://github.com/neovici/cosmoz-dropdown/commit/388c2863a9e20ae84bf501ced2cde4a0ac3925df))
+- adjust storybook ci ([d39ea01](https://github.com/neovici/cosmoz-dropdown/commit/d39ea01114afa32fbb9cced78a19b7661109d20c))
+- adjust tests ([9ae3943](https://github.com/neovici/cosmoz-dropdown/commit/9ae3943143b7b753278fc790c18b552388be11a0))
+- convert to ts ([c074f0e](https://github.com/neovici/cosmoz-dropdown/commit/c074f0e5cfd6bd4c992f8af4fa7945e12c880ba1))
 
 ### Bug Fixes
 
-* adjust tests ([0155b9b](https://github.com/neovici/cosmoz-dropdown/commit/0155b9bbd295b465f55fa55cadf7fe5cfe19f180))
-* build ([52af772](https://github.com/neovici/cosmoz-dropdown/commit/52af772f10d555c65bd69ce9fcf9ea6512bf181f))
-* **lint:** update ([b258ce4](https://github.com/neovici/cosmoz-dropdown/commit/b258ce47c8f04ac6b8b875e1e49b96bec14207bf))
+- adjust tests ([0155b9b](https://github.com/neovici/cosmoz-dropdown/commit/0155b9bbd295b465f55fa55cadf7fe5cfe19f180))
+- build ([52af772](https://github.com/neovici/cosmoz-dropdown/commit/52af772f10d555c65bd69ce9fcf9ea6512bf181f))
+- **lint:** update ([b258ce4](https://github.com/neovici/cosmoz-dropdown/commit/b258ce47c8f04ac6b8b875e1e49b96bec14207bf))
 
 ## [3.0.2](https://github.com/neovici/cosmoz-dropdown/compare/v3.0.1...v3.0.2) (2022-10-25)
 
-
 ### Bug Fixes
 
-* **cosmoz-dropdown:** correct dropdown position in Firefox ([d6cca97](https://github.com/neovici/cosmoz-dropdown/commit/d6cca973a59c37f0d94b4d9f119c07a4ccf3be3a))
+- **cosmoz-dropdown:** correct dropdown position in Firefox ([d6cca97](https://github.com/neovici/cosmoz-dropdown/commit/d6cca973a59c37f0d94b4d9f119c07a4ccf3be3a))
 
 ## [3.0.1](https://github.com/neovici/cosmoz-dropdown/compare/v3.0.0...v3.0.1) (2022-09-20)
 
-
 ### Bug Fixes
 
-* **ci:** add DropdownMenu story ([104848d](https://github.com/neovici/cosmoz-dropdown/commit/104848dee25539ea3fd3ec03b1dbcadf1fc326f8))
+- **ci:** add DropdownMenu story ([104848d](https://github.com/neovici/cosmoz-dropdown/commit/104848dee25539ea3fd3ec03b1dbcadf1fc326f8))
 
 ## [3.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v2.1.0...v3.0.0) (2022-07-19)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **deps:** Upgrade to latest cosmoz-utils.
+- **deps:** Upgrade to latest cosmoz-utils.
 
 ### Features
 
-* **deps:** upgrade cosmoz-utils ([7fdc860](https://github.com/neovici/cosmoz-dropdown/commit/7fdc86086342731a606fb7dc31e09967269475ad))
+- **deps:** upgrade cosmoz-utils ([7fdc860](https://github.com/neovici/cosmoz-dropdown/commit/7fdc86086342731a606fb7dc31e09967269475ad))
 
 ## [2.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v2.0.0...v2.1.0) (2022-06-23)
 
-
 ### Features
 
-* **dropdown:** tweak slots ([1273a7d](https://github.com/neovici/cosmoz-dropdown/commit/1273a7d0037ee3956fdf2f5d61e2740f2105c862))
+- **dropdown:** tweak slots ([1273a7d](https://github.com/neovici/cosmoz-dropdown/commit/1273a7d0037ee3956fdf2f5d61e2740f2105c862))
 
 ## [2.0.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.8.1...v2.0.0) (2022-06-21)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Upgrade to latest lit/haunted
+- Upgrade to latest lit/haunted
 
 ### Features
 
-* upgrade to latest lit/haunted ([76c00e0](https://github.com/neovici/cosmoz-dropdown/commit/76c00e0a28b2b2b3c0fdcc2dc14019b223aaf3cd))
+- upgrade to latest lit/haunted ([76c00e0](https://github.com/neovici/cosmoz-dropdown/commit/76c00e0a28b2b2b3c0fdcc2dc14019b223aaf3cd))
 
 ## [2.0.0-beta.1](https://github.com/neovici/cosmoz-dropdown/compare/v1.8.1...v2.0.0-beta.1) (2022-06-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Upgrade to latest lit/haunted
+- Upgrade to latest lit/haunted
 
 ### Features
 
-* upgrade to latest lit/haunted ([76c00e0](https://github.com/neovici/cosmoz-dropdown/commit/76c00e0a28b2b2b3c0fdcc2dc14019b223aaf3cd))
+- upgrade to latest lit/haunted ([76c00e0](https://github.com/neovici/cosmoz-dropdown/commit/76c00e0a28b2b2b3c0fdcc2dc14019b223aaf3cd))
 
 ### [1.8.1](https://github.com/neovici/cosmoz-dropdown/compare/v1.8.0...v1.8.1) (2022-04-28)
 
-
 ### Bug Fixes
 
-* **cosmoz-dropdown-menu:** limit list height to 96vh-64px ([29e4b03](https://github.com/neovici/cosmoz-dropdown/commit/29e4b03707c161841ab7ca0befd006b01ea30963))
+- **cosmoz-dropdown-menu:** limit list height to 96vh-64px ([29e4b03](https://github.com/neovici/cosmoz-dropdown/commit/29e4b03707c161841ab7ca0befd006b01ea30963))
 
 ## [1.8.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.7.0...v1.8.0) (2022-03-31)
 
-
 ### Features
 
-* **package.json:** remove exports ([847c34d](https://github.com/neovici/cosmoz-dropdown/commit/847c34deb472b6cc1019798a23aca9de1a74457e))
+- **package.json:** remove exports ([847c34d](https://github.com/neovici/cosmoz-dropdown/commit/847c34deb472b6cc1019798a23aca9de1a74457e))
 
 ## [1.7.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.6.0...v1.7.0) (2022-03-31)
 
-
 ### Features
 
-* **package.json:** add exports ([83a4d8e](https://github.com/neovici/cosmoz-dropdown/commit/83a4d8ee5b86f2b2d1e7b3951f637ef762639edb))
+- **package.json:** add exports ([83a4d8e](https://github.com/neovici/cosmoz-dropdown/commit/83a4d8ee5b86f2b2d1e7b3951f637ef762639edb))
 
 ## [1.6.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.5.3...v1.6.0) (2022-03-18)
 
-
 ### Features
 
-* **dropdown:** export part for styles ([02362c0](https://github.com/neovici/cosmoz-dropdown/commit/02362c0e1f20cc03a6f4c70ba48c1bef7a671e01))
+- **dropdown:** export part for styles ([02362c0](https://github.com/neovici/cosmoz-dropdown/commit/02362c0e1f20cc03a6f4c70ba48c1bef7a671e01))
 
 ### [1.5.3](https://github.com/neovici/cosmoz-dropdown/compare/v1.5.2...v1.5.3) (2021-12-22)
 
-
 ### Bug Fixes
 
-* add button id ([84fc376](https://github.com/neovici/cosmoz-dropdown/commit/84fc376c2ab61472e9cb6f310b3b8ec5665d52a9))
+- add button id ([84fc376](https://github.com/neovici/cosmoz-dropdown/commit/84fc376c2ab61472e9cb6f310b3b8ec5665d52a9))
 
 ### [1.5.2](https://github.com/neovici/cosmoz-dropdown/compare/v1.5.1...v1.5.2) (2021-12-21)
 
-
 ### Bug Fixes
 
-* ignore events for slotted svg ([5d61828](https://github.com/neovici/cosmoz-dropdown/commit/5d6182866f3c103314d6e2671e29fb75f1d260e7))
+- ignore events for slotted svg ([5d61828](https://github.com/neovici/cosmoz-dropdown/commit/5d6182866f3c103314d6e2671e29fb75f1d260e7))
 
 ### [1.5.1](https://github.com/neovici/cosmoz-dropdown/compare/v1.5.0...v1.5.1) (2021-12-21)
 
-
 ### Bug Fixes
 
-* box-sizing ([56e2c0f](https://github.com/neovici/cosmoz-dropdown/commit/56e2c0f50012f24813e397f9c1c34f3b32e656b1))
+- box-sizing ([56e2c0f](https://github.com/neovici/cosmoz-dropdown/commit/56e2c0f50012f24813e397f9c1c34f3b32e656b1))
 
 ## [1.5.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.4.0...v1.5.0) (2021-12-21)
 
-
 ### Features
 
-* implement cosmoz-dropdown-menu ([56b3399](https://github.com/neovici/cosmoz-dropdown/commit/56b3399cde4b89ba899847c052d702c322956d28))
-
+- implement cosmoz-dropdown-menu ([56b3399](https://github.com/neovici/cosmoz-dropdown/commit/56b3399cde4b89ba899847c052d702c322956d28))
 
 ### Bug Fixes
 
-* use active typo ([ea0bd45](https://github.com/neovici/cosmoz-dropdown/commit/ea0bd45cfaf4f284fb05badd9023e347bc5e884b))
+- use active typo ([ea0bd45](https://github.com/neovici/cosmoz-dropdown/commit/ea0bd45cfaf4f284fb05badd9023e347bc5e884b))
 
 ## [1.4.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.3.0...v1.4.0) (2021-12-17)
 
-
 ### Features
 
-* **cosmoz-dropdown:** add --cosmoz-dropdown-anchor-spacing ([902472d](https://github.com/neovici/cosmoz-dropdown/commit/902472dbae6ba4f9de2d92bcc6346464aaee7538))
+- **cosmoz-dropdown:** add --cosmoz-dropdown-anchor-spacing ([902472d](https://github.com/neovici/cosmoz-dropdown/commit/902472dbae6ba4f9de2d92bcc6346464aaee7538))
 
 ## [1.3.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.2.1...v1.3.0) (2021-12-17)
 
-
 ### Features
 
-* **dropdown:** add spacing support ([0d4c1db](https://github.com/neovici/cosmoz-dropdown/commit/0d4c1dbf0cbb75976709dff3d76385a17f5ad6ee))
+- **dropdown:** add spacing support ([0d4c1db](https://github.com/neovici/cosmoz-dropdown/commit/0d4c1dbf0cbb75976709dff3d76385a17f5ad6ee))
 
 ### [1.2.1](https://github.com/neovici/cosmoz-dropdown/compare/v1.2.0...v1.2.1) (2021-12-17)
 
-
 ### Bug Fixes
 
-* slotted display ([126e231](https://github.com/neovici/cosmoz-dropdown/commit/126e231e9ac6a6076727b9be76161c038b811e36))
+- slotted display ([126e231](https://github.com/neovici/cosmoz-dropdown/commit/126e231e9ac6a6076727b9be76161c038b811e36))
 
 ## [1.2.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.1.0...v1.2.0) (2021-12-17)
 
-
 ### Features
 
-* design ([5946a2c](https://github.com/neovici/cosmoz-dropdown/commit/5946a2c55926f276aa1d100796012cb76819f60c))
+- design ([5946a2c](https://github.com/neovici/cosmoz-dropdown/commit/5946a2c55926f276aa1d100796012cb76819f60c))
 
 ## [1.1.0](https://github.com/neovici/cosmoz-dropdown/compare/v1.0.3...v1.1.0) (2021-12-17)
 
-
 ### Features
 
-* **use-host-focus:** implement ([66fcc35](https://github.com/neovici/cosmoz-dropdown/commit/66fcc35efb615b74ef4add013c5706d0f75b6725))
-
+- **use-host-focus:** implement ([66fcc35](https://github.com/neovici/cosmoz-dropdown/commit/66fcc35efb615b74ef4add013c5706d0f75b6725))
 
 ### Bug Fixes
 
-* expose placement ([844d77e](https://github.com/neovici/cosmoz-dropdown/commit/844d77ef261b7ea0600798f9687424fe727bae4e))
+- expose placement ([844d77e](https://github.com/neovici/cosmoz-dropdown/commit/844d77ef261b7ea0600798f9687424fe727bae4e))
 
 ### [1.0.3](https://github.com/neovici/cosmoz-dropdown/compare/v1.0.2...v1.0.3) (2021-12-16)
 
-
 ### Bug Fixes
 
-* more exports ([c756b5f](https://github.com/neovici/cosmoz-dropdown/commit/c756b5fb33966d5aee676021cb59c3a3ca312bdb))
+- more exports ([c756b5f](https://github.com/neovici/cosmoz-dropdown/commit/c756b5fb33966d5aee676021cb59c3a3ca312bdb))
 
 ### [1.0.2](https://github.com/neovici/cosmoz-dropdown/compare/v1.0.1...v1.0.2) (2021-12-16)
 
-
 ### Bug Fixes
 
-* correct import ([bfbe691](https://github.com/neovici/cosmoz-dropdown/commit/bfbe6914635240a6001e2f5b0faca0e63a76c627))
+- correct import ([bfbe691](https://github.com/neovici/cosmoz-dropdown/commit/bfbe6914635240a6001e2f5b0faca0e63a76c627))
 
 ### [1.0.1](https://github.com/neovici/cosmoz-dropdown/compare/v1.0.0...v1.0.1) (2021-12-16)
 
-
 ### Bug Fixes
 
-* correct import ([8770331](https://github.com/neovici/cosmoz-dropdown/commit/87703319eb51fa13f353c2c8489ac3becb264d60))
+- correct import ([8770331](https://github.com/neovici/cosmoz-dropdown/commit/87703319eb51fa13f353c2c8489ac3becb264d60))
 
 ## 1.0.0 (2021-12-16)
 
-
 ### Features
 
-* initialize cosmoz-dropdown ([967fc17](https://github.com/neovici/cosmoz-dropdown/commit/967fc173ce66ba0f190fa024455309d384f41c7b))
+- initialize cosmoz-dropdown ([967fc17](https://github.com/neovici/cosmoz-dropdown/commit/967fc173ce66ba0f190fa024455309d384f41c7b))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neovici/cosmoz-dropdown",
-	"version": "7.7.0",
+	"version": "7.7.1",
 	"description": "A simple dropdown web component",
 	"keywords": [
 		"lit-html",


### PR DESCRIPTION
This PR is opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and the packages will be published to npm automatically. If you're not ready to do a release yet, that's fine, whenever you add more changesets to master, this PR will be updated.

# Releases

## @neovici/cosmoz-dropdown@7.7.1

### Patch Changes

- Guard `showPopover`/`hidePopover` calls with optional chaining to prevent crashes on browsers without Popover API support (Chrome < 114, Edge < 114, Safari < 17, Firefox < 125)
- Migrate from semantic-release to changesets